### PR TITLE
e4hd: rename v3d-nxpl to v3d-cortexa15 for kodi

### DIFF
--- a/conf/machine/e4hd.conf
+++ b/conf/machine/e4hd.conf
@@ -2,7 +2,7 @@
 #@NAME: ${MACHINE}
 #@DESCRIPTION: Machine configuration for the ${MACHINE}
 
-MACHINE_FEATURES += " dvb-c v3d-nxpl transcoding"
+MACHINE_FEATURES += " dvb-c v3d-cortexa15 transcoding"
 OPENPLI_FEATURES += " ci qtplugins kodi"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/include/axas-bcm7252.inc
+++ b/conf/machine/include/axas-bcm7252.inc
@@ -16,9 +16,6 @@ PREFERRED_PROVIDER_virtual/mesa ?= "mesa"
 require conf/machine/include/tune-cortexa15.inc
 require conf/machine/include/axas-essential.inc
 
-EXTRA_OECONF_append_pn-kodi = " --with-gpu=v3d"
-EXTRA_OECMAKE_append_pn-kodi += " -DWITH_V3D=nxpl"
-
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 

--- a/conf/machine/include/axas-essential.inc
+++ b/conf/machine/include/axas-essential.inc
@@ -5,7 +5,7 @@ MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	kernel-module-cdfs \
 	\
-	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxpl', 'axas-libgles-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-cortexa15', 'axas-libgles-${MACHINE}' , '', d)} \
 	resizerootfs \
 	partitions-by-name \
 	\


### PR DESCRIPTION
remove the EXTRA_OECONF / EXTRA_OECMAKE not necessary here

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>